### PR TITLE
added suffix in service account name

### DIFF
--- a/addons/external-secrets/main.tf
+++ b/addons/external-secrets/main.tf
@@ -1,6 +1,6 @@
 resource "google_service_account" "external_secrets" {
   project      = var.project_id
-  account_id   = format("%s-%s", var.environment, var.GCP_GSA_NAME)
+  account_id   = format("%s-%s-%s", var.environment, var.GCP_GSA_NAME, var.name)
   display_name = "Service Account for External Secrets"
 }
 

--- a/addons/external-secrets/variables.tf
+++ b/addons/external-secrets/variables.tf
@@ -3,6 +3,11 @@ variable "project_id" {
   type        = string
 }
 
+variable "name" {
+  description = "The suffix name for the resources being created."
+  type        = string
+}
+
 variable "environment" {
   description = "Environment in which the infrastructure is being deployed (e.g., production, staging, development)"
   type        = string

--- a/addons/keda/main.tf
+++ b/addons/keda/main.tf
@@ -1,6 +1,6 @@
 resource "google_service_account" "keda" {
   project      = var.project_id
-  account_id   = format("%s-%s", var.environment, var.GCP_GSA_NAME)
+  account_id   = format("%s-%s-%s", var.environment, var.GCP_GSA_NAME, var.name)
   display_name = "Service Account for Keda Scaler"
 }
 

--- a/addons/keda/variables.tf
+++ b/addons/keda/variables.tf
@@ -3,6 +3,11 @@ variable "project_id" {
   type        = string
 }
 
+variable "name" {
+  description = "The suffix name for the resources being created."
+  type        = string
+}
+
 variable "environment" {
   description = "Environment in which the infrastructure is being deployed (e.g., production, staging, development)"
   type        = string

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,7 @@ module "external_secrets" {
   count  = var.external_secret_enabled ? 1 : 0
 
   project_id               = var.project
+  name                     = var.name
   environment              = var.environment
   enable_service_monitor   = var.service_monitor_crd_enabled
   external_secrets_version = var.external_secrets_version
@@ -53,6 +54,7 @@ module "keda" {
   count                  = var.enable_keda ? 1 : 0
   environment            = var.environment
   project_id             = var.project
+  name                   = var.name
   enable_service_monitor = var.service_monitor_crd_enabled
   keda_version           = var.keda_version
 }


### PR DESCRIPTION
To resolve the same resource exists error for similar environments, added a name suffix in google_service_account.