### PR TITLE
changed service account name

### DIFF
--- a/addons/external-secrets/main.tf
+++ b/addons/external-secrets/main.tf
@@ -40,7 +40,7 @@ resource "helm_release" "external_secrets" {
   values = [
     templatefile("${path.module}/values.yaml", {
       enable_service_monitor = var.enable_service_monitor,
-      service_account_email  = "${var.environment}-${var.GCP_GSA_NAME}@${var.project_id}.iam.gserviceaccount.com"
+      service_account_email  = "${var.environment}-${var.GCP_GSA_NAME}-${var.name}@${var.project_id}.iam.gserviceaccount.com"
     })
   ]
 }

--- a/addons/external-secrets/variables.tf
+++ b/addons/external-secrets/variables.tf
@@ -16,7 +16,7 @@ variable "environment" {
 variable "GCP_GSA_NAME" {
   description = "Google Cloud Service Account name"
   type        = string
-  default     = "external-secrets"
+  default     = "es"
 }
 
 variable "GCP_KSA_NAME" {

--- a/addons/keda/main.tf
+++ b/addons/keda/main.tf
@@ -28,7 +28,7 @@ resource "helm_release" "keda" {
   values = [
     templatefile("${path.module}/values.yaml", {
       enable_service_monitor = var.enable_service_monitor,
-      gcpIAMServiceAccount   = "${var.environment}-${var.GCP_GSA_NAME}@${var.project_id}.iam.gserviceaccount.com"
+      gcpIAMServiceAccount   = "${var.environment}-${var.GCP_GSA_NAME}-${var.name}@${var.project_id}.iam.gserviceaccount.com"
     })
   ]
 }


### PR DESCRIPTION
1. Shorten service account name for external secrets due to character limit.
2. Append service account with name in helm values.